### PR TITLE
Added custom transform function support

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "serve": "rimraf dist && NODE_ENV=development rollup -c --watch",
     "build": "rimraf dist && NODE_ENV=production rollup -c && NODE_ENV=production DISABLE_BABEL=yes rollup -c",
     "test": "jest",
-    "lint": "standard 'src/**'"
+    "lint": "standard 'src/**'",
+    "lint:fix": "standard 'src/**' --fix"
   },
   "main": "dist/maska.umd.js",
   "module": "dist/maska.esm.js",

--- a/src/mask.js
+++ b/src/mask.js
@@ -69,7 +69,7 @@ function process (value, mask, tokens, masked = true) {
     }
   }
 
-  // fix mask that ends with parentesis
+  // fix mask that ends with parenthesis
   while (masked && im < mask.length) { // eslint-disable-line no-unmodified-loop-condition
     const maskCharRest = mask[im]
     if (tokens[maskCharRest]) {
@@ -83,7 +83,16 @@ function process (value, mask, tokens, masked = true) {
   return ret + rest
 }
 
+/**
+ *
+ * @param {String} value
+ * @param {'uppercase' | 'lowercase' | 'transform'} token
+ */
 function tokenTransform (value, token) {
+  if (token.transform) {
+    value = token.transform(value)
+  }
+
   if (token.uppercase) {
     return value.toLocaleUpperCase()
   } else if (token.lowercase) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -19,7 +19,7 @@ function fixInputSelection (el, position, digit) {
     position++
   }
 
-  const selectionRange = (el.type && el.type.match(/^(text|search|password|tel|url)$/i) || !el.type)
+  const selectionRange = el.type ? el.type.match(/^(text|search|password|tel|url)$/i) : !el.type
   if (selectionRange && el === document.activeElement) {
     el.setSelectionRange(position, position)
     setTimeout(function () {
@@ -32,4 +32,9 @@ function isString (val) {
   return Object.prototype.toString.call(val) === '[object String]'
 }
 
-export { event, findInputElement, fixInputSelection, isString }
+export {
+  event,
+  findInputElement,
+  fixInputSelection,
+  isString
+}


### PR DESCRIPTION
Hi!

Thank you for your awesome directive-based solution for mask-input, which appeared compatible with the latest Vue3.

Looking forward your review and thoughts regarding this PR

## Case

We're currently in a process of moving to your solution from another one, and found out that yours one's missing that custom transform functions feature, which is important for our business-logic.

For Eg.: It could allow us to transliterate glyphs from one alphabet to another (see `test/mask.test.js` attached to the commit)

## On documentation

I know it'd be good of me to document the feature, but I really couldn't find the right words so the documentation is out of the scope of this MR.

Anyway, I think you could write something like this instead of the last paragraph of your `## Mask syntax` section:

> 
> ### Custom tokens
> 
> You can add your own tokens by passing them in `maska` directive or `create` method at initialization (see above). **Important**: `pattern` field should be JS _regular expression_ (`/[0-9]/`) or _string without delimiters_ (`"[0-9]"`).
> 
> While specifying custom tokens you can also add a symbol-transformation behavior such as uppercase, lowercase, or even define a transform method yourself:
> 
> ```javascript
> {
>     'A': { pattern: /[a-zA-Z]/, uppercase: true },
>     'a': { pattern: /[a-zA-Z]/, lowercase: true },
>     'T': { pattern: /[0-9]/, transform: (char) => String(Number(char) % 2) } // '1234567890' -> '1010101010'
> }
> ```
> 
> 

## Changelog:
Added custom transform function support alongside uppercase and lowercase
Added tests to an upcoming functionality
Fixed several lint issues manually
Added "lint:fix" npm script
