### PR TITLE
Optional tokens param in type def. mask function

### DIFF
--- a/types/mask.d.ts
+++ b/types/mask.d.ts
@@ -1,1 +1,1 @@
-export default function mask(value: any, mask: any, tokens: any, masked?: boolean): string;
+export default function mask(value: any, mask: any, tokens?: any, masked?: boolean): string;


### PR DESCRIPTION
It seems tokens param should be optional here.