### PR TITLE
[Types] `tokens` should be optional too

### DIFF
--- a/types/mask.d.ts
+++ b/types/mask.d.ts
@@ -1,1 +1,1 @@
-export default function mask(value: any, mask: any, tokens: any, masked?: boolean): string;
+export default function mask(value: any, mask: any, tokens?: any, masked?: boolean): string;


### PR DESCRIPTION
`tokens` param should be optional too, as can be seen in the implementation:

https://github.com/beholdr/maska/blob/5db320a2b21c9c159ad60070e91b3128bad552fd/src/mask.js#L3