### PR TITLE
Return null if input type equals file

### DIFF
--- a/src/directive.ts
+++ b/src/directive.ts
@@ -17,7 +17,7 @@ export const vMaska: MaskaDirective = (el, binding) => {
   const input = el instanceof HTMLInputElement ? el : el.querySelector('input')
   const opts = { ...(binding.arg as MaskInputOptions) } ?? {}
 
-  if (input == null || input.type === 'file') return
+  if (input == null || input?.type === 'file') return
 
   checkValue(input)
 

--- a/src/directive.ts
+++ b/src/directive.ts
@@ -17,7 +17,7 @@ export const vMaska: MaskaDirective = (el, binding) => {
   const input = el instanceof HTMLInputElement ? el : el.querySelector('input')
   const opts = { ...(binding.arg as MaskInputOptions) } ?? {}
 
-  if (input == null) return
+  if (input == null || input.type === 'file') return
 
   checkValue(input)
 


### PR DESCRIPTION
Direcitve doesnt work on inputs with type set to 'file', it throws error when value changes
![image](https://github.com/beholdr/maska/assets/89526742/1f174c7b-ea12-429a-ae7d-033a2b5363a4)
