### PR TITLE
fix(package.json): add typesVersions section into package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maska",
-  "version": "3.0.0-beta",
+  "version": "3.0.0-beta1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "maska",
-      "version": "3.0.0-beta",
+      "version": "3.0.0-beta1",
       "license": "MIT",
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,13 @@
       "require": "./dist/vue.js"
     }
   },
+  "typesVersions": {
+    "*": {
+      "vue": ["dist/vue.d.ts"],
+      "alpine": ["dist/alpine.d.ts"],
+      "svelte": ["dist/svelte.d.ts"]
+    }
+  },
   "scripts": {
     "dev": "vite",
     "docs": "cd docs && http-server",


### PR DESCRIPTION
Current installation method for vue3 app gives:

![image](https://github.com/beholdr/maska/assets/12041086/64660965-97e3-4203-b58c-decc8f9b9b87)

Next section at package.json solves problem for my case
```json
  "typesVersions": {
    "*": {
      "vue": ["dist/vue.d.ts"]
    }
  },
```