### PR TITLE
Fix queueMicrotask working on already destroyed mask instance

### DIFF
--- a/src/input.ts
+++ b/src/input.ts
@@ -53,7 +53,11 @@ export class MaskInput {
       const mask = new Mask(parseInput(input, defaults))
       this.items.set(input, mask)
 
-      queueMicrotask(() => this.updateValue(input))
+      queueMicrotask(() => {
+        if (document.body.contains(input)) {
+          this.updateValue(input)
+        }
+      })
 
       if (input.selectionStart === null && mask.isEager()) {
         console.warn('Maska: input of `%s` type is not supported', input.type)


### PR DESCRIPTION
Looks like due to async nature of `queueMicrotask` we need check, that it still working in dom, which contain this input (dom mutation happend)

![Screenshot 2025-03-19 at 14 16 01](https://github.com/user-attachments/assets/9c0f84e7-ad7f-4fb1-a1cc-a95c9a9e90e0)
