### PR TITLE
feat: useMaska composable

### DIFF
--- a/docs/v3/vue.md
+++ b/docs/v3/vue.md
@@ -1,6 +1,6 @@
 # Usage with Vue
 
-Maska provides custom Vue directive for use with input:
+Maska provides custom Vue directive and Composable for use with input:
 
 ```html
 <input v-maska:argument.modifier="value">
@@ -203,5 +203,109 @@ Vue.directive("maska", vMaska)
 
 // or in case of CDN load
 Vue.directive("maska", Maska.vMaska)
+```
+<!-- tabs:end -->
+
+
+## Usage as Composable
+
+You can use Maska as a composable in your setup script:
+
+```vue
+<script setup>
+  import { ref, useTemplateRef } from "vue";
+  import { useMaska } from "maska/vue"
+
+  const model = ref('');
+
+  const config = {
+    mask: '#-#'
+  }
+
+  const { unmasked, masked, completed } = useMaska(useTemplateRef('input'), config, model);
+</script>
+```
+
+Signature: `useMaska(target, options, model?): UseMaskaReturn`
+
+- `target` is a target maska element (string selector, HTMLElement, ref or computed template element)
+- `options` can be passed as a string (mask template) or an object with configuration:
+  - `maskType`: what value (`masked` or `unmasked`) should be applied to the passed model (default: `unmasked`)
+  - ...other maska [options](/options).
+- `model` is a model (`Ref<string>`) to bind maska value, optionally
+
+<!-- tabs:start -->
+### **Plain template**
+
+```vue
+<script setup>
+  import { useTemplateRef } from "vue"
+  import { useMaska } from "maska/vue"
+
+  const inputEl = useTemplateRef('inputEl')
+
+  const { unmasked: unmaskedValue, masked: maskedValue } = useMaska(inputEl, '#-#')
+</script>
+
+<template>
+  <input ref="inputEl">
+
+  Masked value: {{ maskedValue }}
+  Unmasked value: {{ unmaskedValue }}
+</template>
+```
+
+### **Configurable options**
+
+```vue
+<script setup>
+  import { useTemplateRef } from "vue"
+  import { useMaska } from "maska/vue"
+
+  const options = {
+    mask: '#-#',
+    eager: true
+  }
+
+  const inputEl = useTemplateRef('inputEl')
+
+  const { unmasked: unmaskedValue, masked: maskedValue } = useMaska(inputEl, options)
+</script>
+
+<template>
+  <input ref="inputEl">
+
+  Masked value: {{ maskedValue }}
+  Unmasked value: {{ unmaskedValue }}
+</template>
+```
+
+
+### **Computed options**
+
+```vue
+<script setup>
+  import { computed, ref, useTemplateRef } from 'vue'
+  import { useMaska } from 'maska/vue'
+
+  const modelValue = defineModel({ default: '123' });
+
+  const maskaTemplate = ref('#-#')
+
+  const inputEl = useTemplateRef('inputEl')
+
+  const maskaOptions = computed(() => ({
+    mask: maskaTemplate.value,
+    modelType: 'masked'
+  }))
+
+  const { unmasked } = useMaska(inputEl, maskaOptions, modelValue)
+</script>
+
+<template>
+  <input ref="inputEl" />
+  <input v-model="maskaTemplate" />
+</template>
+
 ```
 <!-- tabs:end -->

--- a/src/vue/composable.ts
+++ b/src/vue/composable.ts
@@ -1,0 +1,205 @@
+import {
+  ComponentPublicInstance,
+  computed,
+  ComputedGetter,
+  isRef,
+  MaybeRefOrGetter,
+  onMounted,
+  onUnmounted,
+  readonly,
+  ref,
+  Ref,
+  shallowRef,
+  ShallowRef,
+  toValue,
+  watch
+} from 'vue'
+import { MaskaDetail, MaskInput, MaskInputOptions } from '../input'
+
+const DEFAULT_MODEL_TYPE = 'unmasked'
+
+export type MaybeElement<T extends HTMLElement = HTMLElement> = T | ComponentPublicInstance | undefined | null
+export type MaybeComputedElementRef<T extends MaybeElement = MaybeElement> = MaybeRefOrGetter<T>
+
+export type RefOrGetter<T> = Ref<T> | ComputedGetter<T>
+
+export function unrefElement<T extends MaybeElement>(elRef: MaybeComputedElementRef<T>): T | undefined {
+  const plain = toValue(elRef)
+  return (plain as ComponentPublicInstance)?.$el ?? plain
+}
+
+export function isRefOrGetter<T>(value: MaybeRefOrGetter<T>): value is RefOrGetter<T> {
+  return isRef(value) || typeof value === 'function'
+}
+
+export type MaskElement = MaybeElement<HTMLInputElement>
+
+export interface UseMaskaReturn {
+  masked: Readonly<Ref<string>>
+  unmasked: Readonly<Ref<string>>
+  completed: Readonly<Ref<boolean>>
+  instance: Readonly<ShallowRef<MaskInput>>
+}
+
+export type MaskaElementTarget = MaybeComputedElementRef<MaskElement>
+export type MaskaSelectorTarget = string
+
+interface UseMaskaModelType {
+  modelType?: 'masked' | 'unmasked'
+}
+
+export type MaskaPattern = MaybeRefOrGetter<string>
+export type MaskaConfig = MaybeRefOrGetter<Partial<MaskInputOptions> & UseMaskaModelType>
+export type MaskaModel = Ref<string | undefined> | undefined
+
+export function useMaska(target: MaskaElementTarget, pattern: MaskaPattern, model?: Ref<string>): UseMaskaReturn
+export function useMaska(target: MaskaElementTarget, config: MaskaConfig, model?: Ref<string>): UseMaskaReturn
+export function useMaska(selector: MaskaSelectorTarget, pattern: MaskaPattern, model?: Ref<string>): UseMaskaReturn
+export function useMaska(selector: MaskaSelectorTarget, config: MaskaConfig, model?: Ref<string>): UseMaskaReturn
+
+export function useMaska(
+  target: MaskaElementTarget | MaskaSelectorTarget,
+  options: MaskaPattern | MaskaConfig,
+  model: MaskaModel = undefined
+): UseMaskaReturn {
+  let prevTarget: HTMLInputElement | undefined | null
+  const instance = shallowRef<MaskInput>()
+
+  const masked = ref('')
+  const unmasked = ref('')
+  const completed = ref(false)
+
+  const modelType = computed(() => {
+    const plainOptions = toValue(options)
+
+    if (typeof plainOptions === 'string') {
+      return DEFAULT_MODEL_TYPE
+    }
+
+    if ((plainOptions as UseMaskaModelType)?.modelType !== undefined) {
+      return (plainOptions as UseMaskaModelType).modelType ?? DEFAULT_MODEL_TYPE
+    }
+
+    return DEFAULT_MODEL_TYPE
+  })
+
+  function getTarget(): Exclude<MaskElement, ComponentPublicInstance> {
+    let el
+
+    if (isRefOrGetter(target)) {
+      el = toValue(target)
+    }
+
+    if (typeof el === 'string') {
+      return document.querySelector(el)
+    }
+
+    if (el != null) {
+      return unrefElement(el) as Exclude<MaskElement, ComponentPublicInstance>
+    }
+
+    return undefined
+  }
+
+  if (model != null) {
+    watch(model, value => {
+      if (instance.value === undefined) {
+        return
+      }
+
+      const targetValue = modelType.value === 'masked' ? masked.value : unmasked.value
+
+      if (targetValue === value) {
+        return
+      }
+
+      const target = getTarget()
+
+      if (target != null) {
+        target.value = value ?? ''
+      }
+    })
+  }
+
+  function onMaska(detail: MaskaDetail): void {
+    masked.value = detail.masked
+    unmasked.value = detail.unmasked
+    completed.value = detail.completed
+
+    if (model != null) {
+      model.value = modelType.value === 'masked' ? detail.masked : detail.unmasked
+    }
+  }
+
+  function createConfig(): MaskInputOptions {
+    const optionsValue = toValue(options)
+
+    if (typeof optionsValue === 'string') {
+      return {
+        onMaska,
+        mask: optionsValue
+      }
+    }
+
+    return {
+      ...optionsValue,
+      onMaska
+    }
+  }
+
+  function initialize(): void {
+    prevTarget = getTarget()
+
+    if (prevTarget == null) {
+      return
+    }
+
+    instance.value = new MaskInput(prevTarget, createConfig())
+
+    if (model != null) {
+      prevTarget.value = model.value ?? ''
+    }
+  }
+
+  function refresh(): void {
+    if (instance.value === undefined) {
+      initialize()
+      return
+    }
+
+    if (prevTarget !== target) {
+      destroy()
+      initialize()
+    }
+  }
+
+  function update(): void {
+    instance.value?.update(createConfig())
+  }
+
+  function destroy(): void {
+    instance.value?.destroy()
+  }
+
+  if (isRefOrGetter(target)) {
+    watch(() => unrefElement(target), value => {
+      if (value != null) refresh()
+    })
+  }
+
+  if (isRefOrGetter(options)) {
+    watch(() => toValue(options as RefOrGetter<MaskInputOptions>), value => {
+      if (value) update()
+    }, { deep: true })
+  }
+
+  onMounted(initialize)
+  onUnmounted(destroy)
+
+  return {
+    masked: readonly(masked),
+    unmasked: readonly(unmasked),
+    completed: readonly(completed),
+    instance: readonly(instance)
+  }
+}

--- a/test/vue/ComputedComposable.vue
+++ b/test/vue/ComputedComposable.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+import { computed, ref, useTemplateRef } from 'vue'
+import { useMaska } from '../../src/vue/composable'
+
+const maskTemplate = ref('#-#')
+
+function setMaskTemplate(value: string) {
+  maskTemplate.value = value
+}
+
+const inputEl = useTemplateRef('inputEl')
+
+const maska = computed(() => ({
+  mask: maskTemplate.value
+}))
+
+const { unmasked } = useMaska(inputEl, maska)
+
+defineExpose({ unmasked, setMaskTemplate })
+
+</script>
+
+<template>
+  <input id="maska" ref="inputEl" />
+  <input v-model="maskTemplate" />
+</template>

--- a/test/vue/Demo.vue
+++ b/test/vue/Demo.vue
@@ -20,6 +20,10 @@ import Multiple from './Multiple.vue'
 import Options from './Options.vue'
 import Parent from './Parent.vue'
 import Simple from './Simple.vue'
+import SimpleComposable from './SimpleComposable.vue'
+import ComputedComposable from './ComputedComposable.vue'
+import HiddenElementComposable from './HiddenElementComposable.vue'
+import DifferentElementComposable from './DifferentElementComposable.vue'
 
 const component = shallowRef(Sink)
 </script>
@@ -45,6 +49,10 @@ const component = shallowRef(Sink)
     <option :value="Options">Options</option>
     <option :value="Parent">Parent</option>
     <option :value="Simple">Simple</option>
+    <option :value="SimpleComposable">SimpleComposable</option>
+    <option :value="ComputedComposable">ComputedComposable</option>
+    <option :value="HiddenElementComposable">HiddenElementComposable</option>
+    <option :value="DifferentElementComposable">DifferentElementComposable</option>
   </select>
 
   <div class="comp">

--- a/test/vue/DifferentElementComposable.vue
+++ b/test/vue/DifferentElementComposable.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+import { computed, ref, useTemplateRef } from 'vue'
+import { useMaska } from '../../src/vue/composable'
+
+const inputEl1 = useTemplateRef('inputEl1')
+const inputEl2 = useTemplateRef('inputEl2')
+
+const inputIsSwitched = ref(false)
+
+const currentInput = computed(() => {
+  return inputIsSwitched.value ? inputEl2.value : inputEl1.value
+})
+
+function switchCurrentInput() {
+  inputIsSwitched.value = !inputIsSwitched.value
+}
+
+const { unmasked, instance } = useMaska(currentInput, '#-#')
+
+defineExpose({ switchCurrentInput, unmasked, instance })
+
+</script>
+
+<template>
+  <input id="inputEl1" ref="inputEl1" />
+  <input id="inputEl2" ref="inputEl2" />
+  <button @click="switchCurrentInput" class="mb-1">toggle current input</button>
+</template>

--- a/test/vue/HiddenElementComposable.vue
+++ b/test/vue/HiddenElementComposable.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import { ref, useTemplateRef } from 'vue'
+import { useMaska } from '../../src/vue/composable'
+
+const inputEl = useTemplateRef('inputEl')
+
+const { unmasked, instance } = useMaska(inputEl, '#-#')
+
+const inputIsVisible = ref(false)
+
+function setIsVisible(value: boolean) {
+  inputIsVisible.value = value
+}
+
+defineExpose({ setIsVisible, unmasked, instance })
+
+</script>
+
+<template>
+  <input v-if="inputIsVisible" ref="inputEl" data-maska="#-#" />
+  <button @click="inputIsVisible = !inputIsVisible">toggle visible</button>
+</template>

--- a/test/vue/ModelComposable.vue
+++ b/test/vue/ModelComposable.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import { ref, useTemplateRef } from 'vue'
+import { useMaska } from '../../src/vue/composable'
+
+const model = ref('123')
+
+const inputEl = useTemplateRef('inputEl')
+
+const { unmasked } = useMaska(inputEl, '#-#', model)
+
+defineExpose({ unmasked, model })
+
+</script>
+
+<template>
+  <input id="maska" ref="inputEl" />
+</template>

--- a/test/vue/SimpleComposable.vue
+++ b/test/vue/SimpleComposable.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import { useTemplateRef } from 'vue'
+import { useMaska } from '../../src/vue/composable'
+
+const inputEl = useTemplateRef('inputEl')
+
+const { unmasked } = useMaska(inputEl, '#-#')
+
+defineExpose({ unmasked })
+
+</script>
+
+<template>
+  <input ref="inputEl" />
+  <p>{{ unmasked }}</p>
+</template>


### PR DESCRIPTION
Привет, надеюсь ты не против, что я напишу на русском

Предлагаю добавить composable для работы с масками.

Я хочу объяснить, почему это может быть полезно:

1. Очень гибкая возможность конфигурации, позволяющая построить любые сценарии
2. Более удобная интеграция с `defineModel()`
3. Скоро в Vue выйдет `Vapor Mode`. Есть опасения, что в нем не будет поддержки директив. Рано или поздно нужно будет переходить на `composables`.

Я описал примеры в документации, написал несколько основных тестов. Разумеется, для полного покрытия тестами этого composable требуется еще много тестов. Но я пока не стал этого делать, чтобы не тратить время теоретически впустую.

Но есть очень важный вопрос. Как лучше интегрировать это в библиотеку и стоит ли?
1. Мы можем указать минимальную версию `vue` в `peerpeerDependencies`
2. Мы можем создать отдельный entry point, например `maska/vue-composable`
3. Можно создать в принципе отдельный репозиторий под `vue-maska`, но какое-нибудь уникальное название придумать офк надо будет
4. Мы можем просто не добавлять это и сказать, что это нафиг не нужно в данной библиотеке

Что ты думаешь по всему этому поводу?